### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/notification/ExposedMessageSourceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/notification/ExposedMessageSourceIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest(properties = {"notificationToSend.autoStartup=false"})
 @Transactional
 public class ExposedMessageSourceIntegrationTest {

--- a/src/integration-test/java/org/openlmis/notification/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/notification/repository/BaseCrudRepositoryIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "notificationToSend.autoStartup=false" })
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest
     <T extends Identifiable<I>, I extends Serializable> {

--- a/src/integration-test/java/org/openlmis/notification/service/NotificationToSendFlowIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/notification/service/NotificationToSendFlowIntegrationTest.java
@@ -71,7 +71,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @RunWith(SpringRunner.class)
 @SuppressWarnings("PMD.TooManyMethods")
 @SpringBootTest(properties = {"notificationToSend.autoStartup=false"})

--- a/src/integration-test/java/org/openlmis/notification/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/notification/web/BaseWebIntegrationTest.java
@@ -57,7 +57,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(
     properties = { "notificationToSend.autoStartup=false" },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 public abstract class BaseWebIntegrationTest {
   private static final String USER_ACCESS_TOKEN = "418c89c5-7f21-4cd1-a63a-38c47892b0fe";
   protected static final String USER_ACCESS_TOKEN_HEADER = "Bearer " + USER_ACCESS_TOKEN;

--- a/src/main/java/org/openlmis/notification/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/notification/TestDataInitializer.java
@@ -28,7 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(TestDataInitializer.class);


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.