### PR TITLE
CQI-21: standarized criteria for report of performance tests

### DIFF
--- a/performance/test.sh
+++ b/performance/test.sh
@@ -14,7 +14,7 @@ echo "Running performance tests against: $URL"
 export BASE_URL="${URL}"
 docker run --rm -e BASE_URL -v $(pwd):/bzt-configs \
   -v $(pwd)/../build/performance-artifacts:/tmp/artifacts \
-  blazemeter/taurus:1.10.3 \
+  blazemeter/taurus:1.65.35 \
   -o modules.jmeter.properties.base-uri="${BASE_URL}" \
   -o reporting.2.dump-xml=/tmp/artifacts/stats.xml \
   config.yml \

--- a/performance/tests/notification.yml
+++ b/performance/tests/notification.yml
@@ -1,6 +1,8 @@
 execution:
-  - concurrency: 1
-    hold-for: 1m
+  - concurrency: 10
+    iterations: 10
+    ramp-up: 1m
+    hold-for: 10m
     scenario: send-notification
 
 scenarios:
@@ -36,6 +38,8 @@ scenarios:
         body: ${notification}
 
 reporting:
-    - module: passfail
-      criteria:
-        Send notification too slow: p90 of SendNotification>500ms
+  - module: passfail
+    criteria:
+      - 'SendNotification too high error rate: failures>1%, continue as failed, label=SendNotification, title="SendNotification error rate too high"'
+      - 'SendNotification is too slow: p90>3000ms, stop as failed, label=SendNotification, title="SendNotification response time too high"'
+      - 'SendNotification needs improvement: p90>2000ms and p90<=3000ms, continue as passed, label=SendNotification, title="SendNotification needs improvement"'


### PR DESCRIPTION
Changes:
1. new execution parameters: 10 concurrency (threads/users), 10 iterations each, ramp up 1 minute for 10 minuts hold
2. reporting standarized

How was it tested?
It did work for performance tests server when ran directly with bzt command.